### PR TITLE
fearure: Directory.Build.props and Directory.Packages.props added to manage build and packages mange them centrally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <Deterministic>true</Deterministic>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/CoreStack.Abstraction/CoreStack.Abstraction.csproj
+++ b/src/CoreStack.Abstraction/CoreStack.Abstraction.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreStack.Api/CoreStack.Api.csproj
+++ b/src/CoreStack.Api/CoreStack.Api.csproj
@@ -2,16 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreStack.Application/CoreStack.Application.csproj
+++ b/src/CoreStack.Application/CoreStack.Application.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreStack.Domain/CoreStack.Domain.csproj
+++ b/src/CoreStack.Domain/CoreStack.Domain.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreStack.Infrastructure/CoreStack.Infrastructure.csproj
+++ b/src/CoreStack.Infrastructure/CoreStack.Infrastructure.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fearure: Directory.Build.props and Directory.Packages.props added to manage build and packages mange them centrally

#### PR Classification
Code cleanup and build configuration improvement.

#### PR Summary
This pull request centralizes project properties and package version management to simplify and standardize configuration across the solution.
- Added Directory.Build.props and Directory.Packages.props to manage common properties and package versions centrally.
- Removed redundant property definitions from all individual project files.
- Updated CoreStack.Api.csproj to reference Microsoft.AspNetCore.OpenApi without specifying the version.
- Enabled central package version management and transitive pinning for NuGet packages.

Closes #3