### PR TITLE
feature: architecture test project added with architect boundries test added. cetralized nudget added to support test project

### DIFF
--- a/CoreStack.slnx
+++ b/CoreStack.slnx
@@ -19,4 +19,7 @@
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
   </Folder>
+  <Folder Name="/Test/">
+    <Project Path="tests/CoreStack.Architecture.Tests/CoreStack.Architecture.Tests.csproj" Id="3d3f0aa5-3678-4ab9-80ae-7856b4c8d0fb" />
+  </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,15 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
 </Project>

--- a/src/CoreStack.Abstraction/AssemblyReference.cs
+++ b/src/CoreStack.Abstraction/AssemblyReference.cs
@@ -1,0 +1,13 @@
+namespace CoreStack.Abstraction;
+
+/// <summary>
+/// Represents a marker type used to reference the containing assembly.
+/// </summary>
+/// <remarks>
+/// Provides a stable reference point for assembly scanning operations.
+/// Enables discovery of types and resources within the assembly.
+/// Supports registration and configuration patterns requiring assembly access.
+/// </remarks>
+public sealed class AssemblyReference
+{
+}

--- a/src/CoreStack.Api/AssemblyReference.cs
+++ b/src/CoreStack.Api/AssemblyReference.cs
@@ -1,0 +1,13 @@
+namespace CoreStack.Api;
+
+/// <summary>
+/// Represents a marker type used to reference the containing assembly.
+/// </summary>
+/// <remarks>
+/// Provides a stable reference point for assembly scanning operations.
+/// Enables discovery of types and resources within the assembly.
+/// Supports registration and configuration patterns requiring assembly access.
+/// </remarks>
+public sealed class AssemblyReference
+{
+}

--- a/src/CoreStack.Application/AssemblyReference.cs
+++ b/src/CoreStack.Application/AssemblyReference.cs
@@ -1,0 +1,13 @@
+namespace CoreStack.Application;
+
+/// <summary>
+/// Represents a marker type used to reference the containing assembly.
+/// </summary>
+/// <remarks>
+/// Provides a stable reference point for assembly scanning operations.
+/// Enables discovery of types and resources within the assembly.
+/// Supports registration and configuration patterns requiring assembly access.
+/// </remarks>
+public sealed class AssemblyReference
+{
+}

--- a/src/CoreStack.Domain/AssemblyReference.cs
+++ b/src/CoreStack.Domain/AssemblyReference.cs
@@ -1,0 +1,13 @@
+namespace CoreStack.Domain;
+
+/// <summary>
+/// Represents a marker type used to reference the containing assembly.
+/// </summary>
+/// <remarks>
+/// Provides a stable reference point for assembly scanning operations.
+/// Enables discovery of types and resources within the assembly.
+/// Supports registration and configuration patterns requiring assembly access.
+/// </remarks>
+public sealed class AssemblyReference
+{
+}

--- a/src/CoreStack.Infrastructure/AssemblyReference.cs
+++ b/src/CoreStack.Infrastructure/AssemblyReference.cs
@@ -1,0 +1,13 @@
+namespace CoreStack.Infrastructure;
+
+/// <summary>
+/// Represents a marker type used to reference the containing assembly.
+/// </summary>
+/// <remarks>
+/// Provides a stable reference point for assembly scanning operations.
+/// Enables discovery of types and resources within the assembly.
+/// Supports registration and configuration patterns requiring assembly access.
+/// </remarks>
+public sealed class AssemblyReference
+{
+}

--- a/tests/CoreStack.Architecture.Tests/ArchitectureTests.cs
+++ b/tests/CoreStack.Architecture.Tests/ArchitectureTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using NetArchTest.Rules;
+using Xunit;
+
+namespace CoreStack.Architecture.Tests;
+
+/// <summary>
+/// Defines architecture validation tests for solution layer dependencies.
+/// </summary>
+/// <remarks>
+/// Verifies dependency rules between solution layers.
+/// Ensures layering constraints are enforced during development.
+/// Uses architecture testing utilities to detect violations.
+/// </remarks>
+public sealed class ArchitectureTests
+{
+    /// <summary>
+    /// Defines the namespace used by the abstractions layer.
+    /// </summary>
+    private const string _abstractionProjectNamespace = "CoreStack.Abstraction";
+
+    /// <summary>
+    /// Defines the namespace used by the API layer.
+    /// </summary>
+    private const string _apiProjectNamespace = "CoreStack.Api";
+
+    /// <summary>
+    /// Defines the namespace used by the application layer.
+    /// </summary>
+    private const string _applicationProjectNamespace = "CoreStack.Application";
+
+    /// <summary>
+    /// Defines the namespace used by the domain layer.
+    /// </summary>
+    private const string _domainProjectNamespace = "CoreStack.Domain";
+
+    /// <summary>
+    /// Defines the namespace used by the infrastructure layer.
+    /// </summary>
+    private const string _infrastructureProjectNamespace = "CoreStack.Infrastructure";
+
+    /// <summary>
+    /// Defines the namespace used by architecture testing utilities.
+    /// </summary>
+    private const string _architectureNamespace = "NetArchTest";
+
+    /// <summary>
+    /// Validates that the domain layer has no external dependencies.
+    /// </summary>
+    /// <remarks>
+    /// Ensures domain types remain independent from other layers.
+    /// Enforces isolation of domain logic.
+    /// </remarks>
+    [Fact]
+    public void Domain_Should_Have_No_Dependencies()
+    {
+        var result = Types.InAssembly(typeof(Domain.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOnAny(
+                _apiProjectNamespace,
+                _applicationProjectNamespace,
+                _abstractionProjectNamespace,
+                _infrastructureProjectNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Validates that the abstractions layer has no external dependencies.
+    /// </summary>
+    /// <remarks>
+    /// Ensures abstractions remain independent from implementation layers.
+    /// Enforces isolation of shared contracts.
+    /// </remarks>
+    [Fact]
+    public void Abstractions_Should_Have_No_Dependencies()
+    {
+        var result = Types.InAssembly(typeof(Abstraction.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOnAny(
+                _apiProjectNamespace,
+                _applicationProjectNamespace,
+                _domainProjectNamespace,
+                _infrastructureProjectNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Validates that the application layer depends only on domain and abstractions.
+    /// </summary>
+    /// <remarks>
+    /// Ensures application logic depends only on allowed layers.
+    /// Enforces correct layering boundaries.
+    /// </remarks>
+    [Fact]
+    public void Application_Should_Only_Depend_On_Domain_And_Abstractions()
+    {
+        var result = Types.InAssembly(typeof(Application.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOnAny(
+                _infrastructureProjectNamespace,
+                _apiProjectNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Validates that the infrastructure layer does not depend on the API layer.
+    /// </summary>
+    /// <remarks>
+    /// Ensures infrastructure implementation remains independent from presentation logic.
+    /// Enforces correct dependency direction.
+    /// </remarks>
+    [Fact]
+    public void Infrastructure_Should_Not_Depend_On_Api()
+    {
+        var result = Types.InAssembly(typeof(Infrastructure.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOn(_apiProjectNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Validates that the API layer does not depend directly on the domain layer.
+    /// </summary>
+    /// <remarks>
+    /// Ensures API interactions occur through application services.
+    /// Enforces proper separation of presentation and domain concerns.
+    /// </remarks>
+    [Fact]
+    public void Api_Should_Not_Depend_On_Domain_Directly()
+    {
+        var result = Types.InAssembly(typeof(Api.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOn(_domainProjectNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Validates that the domain layer does not reference architecture testing utilities.
+    /// </summary>
+    /// <remarks>
+    /// Ensures testing frameworks are not referenced in domain code.
+    /// Enforces strict separation between domain logic and test dependencies.
+    /// </remarks>
+    [Fact]
+    public void Domain_Should_Not_Reference_NetArchTest()
+    {
+        var result = Types.InAssembly(typeof(Domain.AssemblyReference).Assembly)
+            .ShouldNot()
+            .HaveDependencyOn(_architectureNamespace)
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+}

--- a/tests/CoreStack.Architecture.Tests/CoreStack.Architecture.Tests.csproj
+++ b/tests/CoreStack.Architecture.Tests/CoreStack.Architecture.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NetArchTest.Rules" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CoreStack.Abstraction\CoreStack.Abstraction.csproj" />
+    <ProjectReference Include="..\..\src\CoreStack.Api\CoreStack.Api.csproj" />
+    <ProjectReference Include="..\..\src\CoreStack.Application\CoreStack.Application.csproj" />
+    <ProjectReference Include="..\..\src\CoreStack.Domain\CoreStack.Domain.csproj" />
+    <ProjectReference Include="..\..\src\CoreStack.Infrastructure\CoreStack.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
feature: architecture test project added with architect boundries test added. cetralized nudget added to support test project

#### PR Classification
Introduces automated architecture validation to enforce clean layering and dependency rules.

#### PR Summary
Adds a new architecture test project to ensure that solution layers only depend on allowed layers, supporting clean architecture principles.
- Added CoreStack.Architecture.Tests project with xUnit tests using NetArchTest.Rules and FluentAssertions (ArchitectureTests.cs).
- Introduced AssemblyReference marker classes in each main project for assembly scanning.
- Updated Directory.Packages.props to centrally manage and add test-related package versions.
- Registered the new test project in the solution and created its project file with necessary references.

Closes #5