### PR TITLE
fix: disable SA1101 from stylecop to have consistant ruleset for this qualifier usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -174,6 +174,7 @@ dotnet_diagnostic.SA1633.severity = none
 dotnet_diagnostic.SA1309.severity = none
 dotnet_diagnostic.SA1200.severity = none
 dotnet_diagnostic.SA1010.severity = none
+dotnet_diagnostic.SA1101.severity = none
 
 ########################################
 # DISABLED RULES


### PR DESCRIPTION
fix: disable SA1101 from stylecop to have consistant ruleset for this qualifier usage

Closes #27 

