### PR TITLE
fix: stylecop SA1642 rule overided to loosen the rule set for documentation on class constructor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -175,6 +175,7 @@ dotnet_diagnostic.SA1309.severity = none
 dotnet_diagnostic.SA1200.severity = none
 dotnet_diagnostic.SA1010.severity = none
 dotnet_diagnostic.SA1101.severity = none
+dotnet_diagnostic.SA1642.severity = none
 
 ########################################
 # DISABLED RULES


### PR DESCRIPTION
fix: stylecop SA1642 rule overided to loosen the rule set for documentation on class constructor

Closes #29