### PR TITLE
Relax StyleCop rule SA1623 for property documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -176,6 +176,7 @@ dotnet_diagnostic.SA1200.severity = none
 dotnet_diagnostic.SA1010.severity = none
 dotnet_diagnostic.SA1101.severity = none
 dotnet_diagnostic.SA1642.severity = none
+dotnet_diagnostic.SA1623.severity = none
 
 ########################################
 # DISABLED RULES


### PR DESCRIPTION
fix: stylecop rule for documentation should start with gets SA1623  is relazed to allow more natural human readable comments and code documentation

Closes #44 